### PR TITLE
Tratamento de erros

### DIFF
--- a/crud-angular/src/app/cadastros/cadastros.module.ts
+++ b/crud-angular/src/app/cadastros/cadastros.module.ts
@@ -1,21 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
+import { SharedModule } from '../shared/shared.module';
 import { AppMaterialModule } from './../shared/app-material/app-material.module';
 import { CadastrosRoutingModule } from './cadastros-routing.module';
 import { CadastrosComponent } from './cadastros/cadastros.component';
-
-
-
-
-
 
 @NgModule({
   declarations: [CadastrosComponent],
   imports: [
     CommonModule,
     CadastrosRoutingModule,
-    AppMaterialModule
+    AppMaterialModule,
+    SharedModule
 
   ],
 })

--- a/crud-angular/src/app/cadastros/cadastros/cadastros.component.ts
+++ b/crud-angular/src/app/cadastros/cadastros/cadastros.component.ts
@@ -1,26 +1,41 @@
-import { Cadastro } from './../models/cadastro';
+import { ErrorDialogComponent } from './../../shared/components/error-dialog/error-dialog.component';
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { catchError, Observable, of } from 'rxjs';
 import { CadastrosService } from '../services/cadastros.service';
-import { Observable } from 'rxjs';
+import { Cadastro } from './../models/cadastro';
 
 @Component({
   selector: 'app-cadastros',
   templateUrl: './cadastros.component.html',
   styleUrls: ['./cadastros.component.scss'],
 })
-export class CadastrosComponent implements OnInit {
+export class CadastrosComponent  {
   // Devido ao modo strict estar como true, temos obrigatóriamente que iniciar essa variavel, o que tbm pode ser feito no constructor.
   cadastros$:Observable <Cadastro[]>;
 
   //Colunas que serão exibidas
   displayedColumns = ['_id', 'nome', 'categoria'];
 
-  constructor(private cadastroService: CadastrosService) {
-    this.cadastros$ = this.cadastroService.listaTudo();
-  }
+  constructor(
+    private cadastroService: CadastrosService,
+    public dialog: MatDialog
+    ) {
+    this.cadastros$ = this.cadastroService.listaTudo()
+    .pipe(
+      catchError(error =>{
+        this.onError('Erro ao carregar cadastros.');
+        return of([])
+      })
+    );
 
-  ngOnInit(): void {
 
-
-  }
 }
+ onError(errorMsg: string) {
+    this.dialog.open(ErrorDialogComponent, {
+      data: errorMsg
+    });
+  }
+  }
+
+

--- a/crud-angular/src/app/shared/app-material/app-material.module.ts
+++ b/crud-angular/src/app/shared/app-material/app-material.module.ts
@@ -3,6 +3,8 @@ import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   exports: [
@@ -10,6 +12,8 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatTableModule,
     MatToolbarModule,
     MatProgressSpinnerModule,
+    MatDialogModule,
+    MatButtonModule,
   ],
 })
 export class AppMaterialModule {}

--- a/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.html
+++ b/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.html
@@ -1,0 +1,8 @@
+<div class="msgError">
+    <h1 mat-dialog-title>ERRO!</h1>
+</div>
+<div mat-dialog-content>
+    {{ msgError }}</div>
+<div mat-dialog-actions align="center">
+    <button mat-stroked-button mat-dialog-close>Fechar</button>
+</div>

--- a/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.scss
+++ b/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.scss
@@ -1,0 +1,4 @@
+.msgError {
+    text-align: center;
+    color: red;
+}

--- a/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.spec.ts
+++ b/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorDialogComponent } from './error-dialog.component';
+
+describe('ErrorDialogComponent', () => {
+  let component: ErrorDialogComponent;
+  let fixture: ComponentFixture<ErrorDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ErrorDialogComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.ts
+++ b/crud-angular/src/app/shared/components/error-dialog/error-dialog.component.ts
@@ -1,0 +1,14 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-error-dialog',
+  templateUrl: './error-dialog.component.html',
+  styleUrls: ['./error-dialog.component.scss'],
+})
+export class ErrorDialogComponent  {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public msgError: string) {}
+
+
+}

--- a/crud-angular/src/app/shared/shared.module.ts
+++ b/crud-angular/src/app/shared/shared.module.ts
@@ -1,0 +1,11 @@
+import { AppMaterialModule } from './app-material/app-material.module';
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ErrorDialogComponent } from './components/error-dialog/error-dialog.component';
+
+@NgModule({
+  declarations: [ErrorDialogComponent],
+  imports: [CommonModule, AppMaterialModule],
+  exports: [ErrorDialogComponent],
+})
+export class SharedModule {}


### PR DESCRIPTION
Esse tratamento é para se der algum erro ao carregar a lista de cadastros.

Para provocar o erro 440, coloquei uma letra a mais no nome da API, do arquivo de service.